### PR TITLE
Change TheClams/SystemVerilog submodule to use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -218,4 +218,4 @@
 	url = https://github.com/hesstobi/sublime_gnuplot
 [submodule "assets/syntaxes/02_Extra/SystemVerilog"]
 	path = assets/syntaxes/02_Extra/SystemVerilog
-	url = git@github.com:TheClams/SystemVerilog.git
+	url = https://github.com/TheClams/SystemVerilog.git


### PR DESCRIPTION
Using SSH to fetch the submodule was causing build failures for me, and as mentioned in [#1581](https://github.com/sharkdp/bat/pull/1581), this should be changed to HTTPS